### PR TITLE
Bump actions/checkout to v4.0.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     - name: checkout
-      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.3
+      uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # pin@v4.0.0
       with:
         fetch-depth: 0 # needed to checkout all branches
 


### PR DESCRIPTION
# Bump `actions/checkout` to `v4.0.0`

This pull request bumps `actions/checkout` to [`v4.0.0`](https://github.com/actions/checkout/releases/tag/v4.0.0)

From the `actions/checkout` folks: 

> Node12 was deleted from runner. Node20 was added to Actions Runner on v2.308.0.
> Node16 has en end of life on 11 Sep 2023.
> This PR updates the default runtime to node20, rather then node16